### PR TITLE
Add roeldev/iac-talos-cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Collection of awesome talos resource from the community
 <details open><summary><h2>Management</h2></summary>
 
   - [cluster-template](https://github.com/onedr0p/cluster-template) Opinionated template for deployment a talos cluster
+  - [terraform proxmox cluster](https://github.com/roeldev/iac-talos-cluster) Deploy a Talos OS-based cluster in Proxmox using Terraform, with Cilium and ArgoCD
   - [terraform vsphere cluster](https://github.com/ilpozzd/terraform-talos-vsphere-cluster) Deploy a Kubernetes cluster based on Talos OS in vSphere
   - [terraform vsphere vm](https://github.com/ilpozzd/terraform-talos-vsphere-vm) Deploy a Talos OS-based vSphere virtual machine in vSphere
-  - [terraform proxmox cluster](https://github.com/roeldev/iac-talos-cluster) Deploy a Talos OS-based cluster in Proxmox using Terraform, with Cilium and ArgoCD
+  

--- a/README.md
+++ b/README.md
@@ -15,3 +15,4 @@ Collection of awesome talos resource from the community
   - [cluster-template](https://github.com/onedr0p/cluster-template) Opinionated template for deployment a talos cluster
   - [terraform vsphere cluster](https://github.com/ilpozzd/terraform-talos-vsphere-cluster) Deploy a Kubernetes cluster based on Talos OS in vSphere
   - [terraform vsphere vm](https://github.com/ilpozzd/terraform-talos-vsphere-vm) Deploy a Talos OS-based vSphere virtual machine in vSphere
+  - [terraform proxmox cluster](https://github.com/roeldev/iac-talos-cluster) Deploy a Talos OS-based cluster in Proxmox using Terraform, with Cilium and ArgoCD


### PR DESCRIPTION
As requested on LinkedIn. My approach to setting up a Talos cluster on Proxmox using Terraform, with Cilium as CNI and ArgoCD to boot the remaining services.