### PR TITLE
[WIP] Adding talos-ansible-playbooks link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,4 @@ Collection of awesome talos resource from the community
 <details open><summary><h2>Tools</h2></summary>
   
 - [talhelper](https://github.com/budimanjojo/talhelper) A tool to help creating Talos configuration files declaratively
+- [talos-ansible-playbooks](https://github.com/mgrzybek/talos-ansible-playbooks) Ansible playbooks to manage Talos Linux deployments


### PR DESCRIPTION
Hi,

`talos-ansible-playbooks` is a set of playbooks used to deploy and manage a cluster:
- day-0: set prerequisites to deploy a cluster
- day-1: create configurations and deploy a cluster
- day-2: upgrade or destroy resources (WIP)

I’m not sure if the _tools_ section is the right one,  _management_  maybe?