### PR TITLE
Add talos-bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,4 @@ Collection of awesome talos resource from the community
 <details open><summary><h2>Tools</h2></summary>
   
 - [talhelper](https://github.com/budimanjojo/talhelper) A tool to help creating Talos configuration files declaratively
+- [talos-bootstrap](https://github.com/aenix-io/talos-bootstrap) An interactive Talos Linux installer


### PR DESCRIPTION
talos-bootstrap is an interactive script for bootstrapping Kubernetes clusters on Talos OS.

*Example: bootstrap full-feature Kubernetes cluster in 5 minutes*:
[![screencast](https://raw.githubusercontent.com/aenix-io/talos-bootstrap/2cc7b82065747e373cd914c87c8cd5c6582c5c6c/images/627123.gif)](https://asciinema.org/a/gwK85Tdr577GsxjXWo7otPFjv)
