### PR TITLE
remove-supported-hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Collection of awesome talos resource from the community
 - [terraform proxmox cluster](https://github.com/roeldev/iac-talos-cluster) Deploy a Talos OS-based cluster in Proxmox using Terraform, with Cilium and ArgoCD
 - [terraform vsphere cluster](https://github.com/ilpozzd/terraform-talos-vsphere-cluster) Deploy a Kubernetes cluster based on Talos OS in vSphere
 - [terraform vsphere vm](https://github.com/ilpozzd/terraform-talos-vsphere-vm) Deploy a Talos OS-based vSphere virtual machine in vSphere
-- [TJ&#39;s Kubernetes Service](https://github.com/zimmertr/TJs-Kubernetes-Service) Terraform template for running HA Talos cluster on Proxmox
+- [TJ's Kubernetes Service](https://github.com/zimmertr/TJs-Kubernetes-Service) Terraform template for running HA Talos cluster on Proxmox
 - [turnk8s](https://github.com/infraheads/turnk8s) Deploy Talos Linux based turnkey k8s clusters in a GitOps way on Proxmox with Netris and ArgoCD
 
 <details open><summary><h2>Tools</h2></summary>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Awesome Talos
+
 Collection of awesome talos resource from the community
 
 ## Table of Contents
@@ -18,8 +19,12 @@ Collection of awesome talos resource from the community
 - [Terraform Talos Hetzner](https://github.com/miran248/terraform-talos-modules) Terraform modules for Talos on Hetzner
 
 <details open><summary><h2>Hardware</h2></summary>
-  
+
 - [Turing Pi v2](https://github.com/ro11net/tpi2-talos) Talos on Jetson Nano cluster
+> Orange Pi5 and Turing RK1 Are Officaly Supported by Talos after 1.9
+- [Orange Pi 5](https://github.com/schneid-l/talos-orangepi5) Support for Orange Pi SBC 
+- [Turing RK1](https://github.com/nberlee/talos) Support Turing RK1 Compute module
+
 
 <details open><summary><h2>Distributions</h2></summary>
 
@@ -27,17 +32,17 @@ Collection of awesome talos resource from the community
 - [kargo](https://github.com/ContainerCraft/Kargo) ContainerCraft Kubevirt PaaS Undercloud
 
 <details open><summary><h2>Libraries</h2></summary>
-  
+
 - [talos-linux-api](https://github.com/stereobutter/talos-linux-api) 🐍 Python bindings for the Talos Linux gRPC API
 
 <details open><summary><h2>Management</h2></summary>
 
-  - [cluster-template](https://github.com/onedr0p/cluster-template) Opinionated template for deployment a talos cluster
-  - [terraform proxmox cluster](https://github.com/roeldev/iac-talos-cluster) Deploy a Talos OS-based cluster in Proxmox using Terraform, with Cilium and ArgoCD
-  - [terraform vsphere cluster](https://github.com/ilpozzd/terraform-talos-vsphere-cluster) Deploy a Kubernetes cluster based on Talos OS in vSphere
-  - [terraform vsphere vm](https://github.com/ilpozzd/terraform-talos-vsphere-vm) Deploy a Talos OS-based vSphere virtual machine in vSphere
-  - [TJ's Kubernetes Service](https://github.com/zimmertr/TJs-Kubernetes-Service) Terraform template for running HA Talos cluster on Proxmox
-  - [turnk8s](https://github.com/infraheads/turnk8s) Deploy Talos Linux based turnkey k8s clusters in a GitOps way on Proxmox with Netris and ArgoCD
+- [cluster-template](https://github.com/onedr0p/cluster-template) Opinionated template for deployment a talos cluster
+- [terraform proxmox cluster](https://github.com/roeldev/iac-talos-cluster) Deploy a Talos OS-based cluster in Proxmox using Terraform, with Cilium and ArgoCD
+- [terraform vsphere cluster](https://github.com/ilpozzd/terraform-talos-vsphere-cluster) Deploy a Kubernetes cluster based on Talos OS in vSphere
+- [terraform vsphere vm](https://github.com/ilpozzd/terraform-talos-vsphere-vm) Deploy a Talos OS-based vSphere virtual machine in vSphere
+- [TJ&#39;s Kubernetes Service](https://github.com/zimmertr/TJs-Kubernetes-Service) Terraform template for running HA Talos cluster on Proxmox
+- [turnk8s](https://github.com/infraheads/turnk8s) Deploy Talos Linux based turnkey k8s clusters in a GitOps way on Proxmox with Netris and ArgoCD
 
 <details open><summary><h2>Tools</h2></summary>
 
@@ -47,6 +52,3 @@ Collection of awesome talos resource from the community
 - [talos-ansible-playbooks](https://github.com/mgrzybek/talos-ansible-playbooks) Ansible playbooks to manage Talos Linux deployments
 - [talos-bootstrap](https://github.com/aenix-io/talos-bootstrap) An interactive Talos Linux installer
 - [talswitcher](https://github.com/mirceanton/talswitcher) A simple tool to help manage multiple talosconfig files
-
-
-

--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@ Collection of awesome talos resource from the community
 
 <details open><summary><h2>Hardware</h2></summary>
   
-- [Orange Pi 5](https://github.com/schneid-l/talos-orangepi5) Support for Orange Pi SBC
 - [Turing Pi v2](https://github.com/ro11net/tpi2-talos) Talos on Jetson Nano cluster
-- [Turing RK1](https://github.com/nberlee/talos) Support Turing RK1 Compute module
 
 <details open><summary><h2>Distributions</h2></summary>
 


### PR DESCRIPTION
Remove turingrk1 and orangepi-5 links.

Because Talos supported them official [https://github.com/siderolabs/sbc-rockchip](https://github.com/siderolabs/sbc-rockchip)