### PR TITLE
feat: Add Talos operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Collection of awesome talos resource from the community
 - [terraform vsphere cluster](https://github.com/ilpozzd/terraform-talos-vsphere-cluster) Deploy a Kubernetes cluster based on Talos OS in vSphere
 - [terraform vsphere vm](https://github.com/ilpozzd/terraform-talos-vsphere-vm) Deploy a Talos OS-based vSphere virtual machine in vSphere
 - [Talos Hetzner Dedicated Control](https://github.com/ErikLundJensen/thdctl) CLI to create Talos based Kubernetes clusters with Hetzner dedicated servers
+- [Talos Operator](https://github.com/alperencelik/talos-operator) A Kubernetes operator to manage Talos Linux clusters on Kubernetes
 - [TJ's Kubernetes Service](https://github.com/zimmertr/TJs-Kubernetes-Service) Terraform template for running HA Talos cluster on Proxmox
 - [turnk8s](https://github.com/infraheads/turnk8s) Deploy Talos Linux based turnkey k8s clusters in a GitOps way on Proxmox with Netris and ArgoCD
 - [talos-controlplane-on-k8s](https://github.com/blackliner/talos-controlplane-on-k8s) Run a Talos controlplane inside a Kubernetes cluster


### PR DESCRIPTION
Talos-operator is a Kubernetes operator for managing Talos Linux clusters using Custom Resources. It offers two primary modes: "container" and "metal". The container mode allows you to bootstrap Talos Linux clusters as Kubernetes pods. The metal mode supports physical and virtual machines that have been booted with Talos Linux and are waiting in maintenance mode. 

Repo: https://github.com/alperencelik/talos-operator

Documentation: https://alperencelik.github.io/talos-operator