### PR TITLE
Add talos-extension-playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,5 +80,6 @@ Collection of awesome talos resource from the community
 - [talos-ansible-playbooks](https://github.com/mgrzybek/talos-ansible-playbooks) Ansible playbooks to manage Talos Linux deployments
 - [talos-bootstrap](https://github.com/aenix-io/talos-bootstrap) An interactive Talos Linux installer
 - [talswitcher](https://github.com/mirceanton/talswitcher) A simple tool to help manage multiple talosconfig files
+- [talos-extension-playground](https://github.com/rezachalak/talos-extension-playground) A simple tool to help extension development
 
 </details>


### PR DESCRIPTION
A playground to help create custom extensions and applying on a running talos cluster.