### PR TITLE
docs: add talos-ufs in the Hardware section

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Collection of awesome talos resource from the community
 > Orange Pi5 and Turing RK1 Are Officaly Supported by Talos after 1.9
 - [Orange Pi 5](https://github.com/schneid-l/talos-orangepi5) Support for Orange Pi SBC 
 - [Turing RK1](https://github.com/nberlee/talos) Support Turing RK1 Compute module
+- [x86_64 UFS](https://github.com/amoyrtil/talos-ufs) Custom Talos Linux builds with UFS (Universal Flash Storage) driver support for x86_64 devices
 
 </details>
 


### PR DESCRIPTION
Adds [talos-ufs](https://github.com/amoyrtil/talos-ufs) in the Hardware section.